### PR TITLE
lnrpc+macaroon: don't write subserver macaroons when stateless_init is set

### DIFF
--- a/lnd.go
+++ b/lnd.go
@@ -420,7 +420,9 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) error {
 	if !cfg.NoMacaroons {
 		// Create the macaroon authentication/authorization service.
 		macaroonService, err = macaroons.NewService(
-			cfg.networkDir, macaroons.IPLockChecker,
+			cfg.networkDir,
+			walletInitParams.StatelessInit,
+			macaroons.IPLockChecker,
 		)
 		if err != nil {
 			err := fmt.Errorf("unable to set up macaroon "+

--- a/lnrpc/invoicesrpc/invoices_server.go
+++ b/lnrpc/invoicesrpc/invoices_server.go
@@ -91,8 +91,10 @@ func New(cfg *Config) (*Server, lnrpc.MacaroonPerms, error) {
 	)
 
 	// Now that we know the full path of the invoices macaroon, we can
-	// check to see if we need to create it or not.
-	if !lnrpc.FileExists(macFilePath) && cfg.MacService != nil {
+	// check to see if we need to create it or not. If stateless_init is set
+	// then we don't write the macaroons.
+	if cfg.MacService != nil && !cfg.MacService.StatelessInit &&
+		!fileExists(macFilePath) {
 		log.Infof("Baking macaroons for invoices RPC Server at: %v",
 			macFilePath)
 
@@ -309,4 +311,15 @@ func (s *Server) AddHoldInvoice(ctx context.Context,
 	return &AddHoldInvoiceResp{
 		PaymentRequest: string(dbInvoice.PaymentRequest),
 	}, nil
+}
+
+// fileExists reports whether the named file or directory exists.
+// This function is taken from https://github.com/btcsuite/btcd
+func fileExists(name string) bool {
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
 }

--- a/lnrpc/routerrpc/router_server.go
+++ b/lnrpc/routerrpc/router_server.go
@@ -120,16 +120,6 @@ type Server struct {
 // gRPC service.
 var _ RouterServer = (*Server)(nil)
 
-// fileExists reports whether the named file or directory exists.
-func fileExists(name string) bool {
-	if _, err := os.Stat(name); err != nil {
-		if os.IsNotExist(err) {
-			return false
-		}
-	}
-	return true
-}
-
 // New creates a new instance of the RouterServer given a configuration struct
 // that contains all external dependencies. If the target macaroon exists, and
 // we're unable to create it, then an error will be returned. We also return
@@ -145,9 +135,11 @@ func New(cfg *Config) (*Server, lnrpc.MacaroonPerms, error) {
 	}
 
 	// Now that we know the full path of the router macaroon, we can check
-	// to see if we need to create it or not.
+	// to see if we need to create it or not. If stateless_init is set
+	// then we don't write the macaroons.
 	macFilePath := cfg.RouterMacPath
-	if !fileExists(macFilePath) && cfg.MacService != nil {
+	if cfg.MacService != nil && !cfg.MacService.StatelessInit &&
+		!fileExists(macFilePath) {
 		log.Infof("Making macaroons for Router RPC Server at: %v",
 			macFilePath)
 
@@ -608,4 +600,15 @@ func (s *Server) SubscribeHtlcEvents(req *SubscribeHtlcEventsRequest,
 			return errServerShuttingDown
 		}
 	}
+}
+
+// fileExists reports whether the named file or directory exists.
+// This function is taken from https://github.com/btcsuite/btcd
+func fileExists(name string) bool {
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
 }

--- a/lnrpc/walletrpc/walletkit_server.go
+++ b/lnrpc/walletrpc/walletkit_server.go
@@ -147,9 +147,11 @@ func New(cfg *Config) (*WalletKit, lnrpc.MacaroonPerms, error) {
 	}
 
 	// Now that we know the full path of the wallet kit macaroon, we can
-	// check to see if we need to create it or not.
+	// check to see if we need to create it or not. If stateless_init is set
+	// then we don't write the macaroons.
 	macFilePath := cfg.WalletKitMacPath
-	if !lnrpc.FileExists(macFilePath) && cfg.MacService != nil {
+	if cfg.MacService != nil && !cfg.MacService.StatelessInit &&
+		!fileExists(macFilePath) {
 		log.Infof("Baking macaroons for WalletKit RPC Server at: %v",
 			macFilePath)
 
@@ -818,4 +820,15 @@ func (w *WalletKit) LabelTransaction(ctx context.Context,
 
 	err = w.cfg.Wallet.LabelTransaction(*hash, req.Label, req.Overwrite)
 	return &LabelTransactionResponse{}, err
+}
+
+// fileExists reports whether the named file or directory exists.
+// This function is taken from https://github.com/btcsuite/btcd
+func fileExists(name string) bool {
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
 }

--- a/macaroons/service.go
+++ b/macaroons/service.go
@@ -28,6 +28,9 @@ var (
 type Service struct {
 	bakery.Bakery
 
+	// Tells the Service if it should write macaroons to disk or not
+	StatelessInit bool
+
 	rks *RootKeyStorage
 }
 
@@ -38,7 +41,7 @@ type Service struct {
 // listing the same checker more than once is not harmful. Default checkers,
 // such as those for `allow`, `time-before`, `declared`, and `error` caveats
 // are registered automatically and don't need to be added.
-func NewService(dir string, checks ...Checker) (*Service, error) {
+func NewService(dir string, statelessInit bool, checks ...Checker) (*Service, error) {
 	// Ensure that the path to the directory exists.
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		if err := os.MkdirAll(dir, 0700); err != nil {
@@ -81,7 +84,7 @@ func NewService(dir string, checks ...Checker) (*Service, error) {
 		}
 	}
 
-	return &Service{*svc, rootKeyStore}, nil
+	return &Service{*svc, statelessInit, rootKeyStore}, nil
 }
 
 // isRegistered checks to see if the required checker has already been

--- a/macaroons/service_test.go
+++ b/macaroons/service_test.go
@@ -61,7 +61,7 @@ func TestNewService(t *testing.T) {
 
 	// Second, create the new service instance, unlock it and pass in a
 	// checker that we expect it to add to the bakery.
-	service, err := macaroons.NewService(tempDir, macaroons.IPLockChecker)
+	service, err := macaroons.NewService(tempDir, false, macaroons.IPLockChecker)
 	if err != nil {
 		t.Fatalf("Error creating new service: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestValidateMacaroon(t *testing.T) {
 	// First, initialize the service and unlock it.
 	tempDir := setupTestRootKeyStorage(t)
 	defer os.RemoveAll(tempDir)
-	service, err := macaroons.NewService(tempDir, macaroons.IPLockChecker)
+	service, err := macaroons.NewService(tempDir, false, macaroons.IPLockChecker)
 	if err != nil {
 		t.Fatalf("Error creating new service: %v", err)
 	}

--- a/walletunlocker/service.go
+++ b/walletunlocker/service.go
@@ -524,7 +524,7 @@ func (u *UnlockerService) ChangePassword(ctx context.Context,
 	err = func(dbDir string, oldPw, newPw []byte, rotateKey bool) error {
 		// Attempt to open the macaroon DB, unlock it and then change
 		// the passphrase.
-		macaroonService, err := macaroons.NewService(dbDir)
+		macaroonService, err := macaroons.NewService(dbDir, in.StatelessInit)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This will prevent the subservers from writing macaroons to disk when the stateless_init flag is set to true. It accomplishes this by storing the StatelessInit value in the Macaroon Service. Then each subserver inspects the StatelessInit value because writing macaroons.